### PR TITLE
(feat) Add google api for geocoding [Closes #24]

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -2,7 +2,8 @@ angular.module('uberxplore', [
   'uberxplore.itineraryList',
   'uberxplore.explore',
   'uberxplore.locations',
-  'uberxplore.services',
+  'uberxplore.uber',
+  'uberxplore.google',
   'ngTouch',
   'ui.router'
 ])

--- a/client/app/services/google.js
+++ b/client/app/services/google.js
@@ -1,0 +1,18 @@
+angular.module('uberxplore.google', [])
+.factory('Google', function($http) {
+  var geocode = function(address) {
+    if( Array.isArray(address) ) {
+      // if yelp address property passed in, join it into one string
+      address = address.join(', ');
+    }
+    return $http.get('/google/geocode', {params: {address: address}}).then(function(response) {
+      return response.data.results[0].geometry.location; // object with `lat` and `lng` properties
+    }, function(err) {
+      console.log(err);
+    });
+  };
+
+  return {
+    geocode: geocode
+  };
+});

--- a/client/app/services/uber.js
+++ b/client/app/services/uber.js
@@ -1,4 +1,4 @@
-angular.module('uberxplore.services', [])
+angular.module('uberxplore.uber', [])
 .factory('Uber', function($http) {
 
   // var signin = function() {

--- a/client/index.html
+++ b/client/index.html
@@ -21,6 +21,7 @@
     <script src="app/itinerary/map/itineraryMap.js"></script>
     <script src="app/services/locations.js"></script>
     <script src="app/services/uber.js"></script>
+    <script src="app/services/google.js"></script>
     <script src="app/app.js"></script>
   </body>
 </html>

--- a/server/google/googleHandler.js
+++ b/server/google/googleHandler.js
@@ -1,0 +1,21 @@
+var request = require('request');
+var url = require('url');
+
+var google = {};
+
+google.geocode_url = 'https://maps.googleapis.com/maps/api/geocode/json';
+google.api_key = 'AIzaSyA8m1HUl86kgHLfYTggYYRIEMhnPZF36-8';
+
+google.geocode = function(req, res, next) {
+  console.log('google geocode server');
+  var parts = url.parse(req.url);
+  request.get({
+    url: google.geocode_url+'?'+parts.query+'&key='+google.api_key,
+    json: true
+  }, function(err, data, results) {
+    if( err ) throw(err);
+    res.send(results);
+  });
+};
+
+module.exports = google;

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ var path = require('path');
 var yelp = require('./yelp/yelpHandler.js');
 var utils = require('./yelp/utils.js');
 var uber = require('./uber/uberHandler.js');
+var google = require('./google/googleHandler.js');
 
 var app = express();
 
@@ -68,6 +69,11 @@ uberRouter.get('/requests/details', uber.getRideDetails);
 uberRouter.get('/requests/map', uber.getRideMap);
 uberRouter.get('/requests/receipt', uber.getRideReceipt);
 app.use('/uber', uberRouter);
+
+
+var googleRouter = express.Router();
+googleRouter.get('/geocode', google.geocode);
+app.use('/google', googleRouter);
 
 var port = process.env.PORT || 1337;
 app.listen(port, function () {


### PR DESCRIPTION
Also renamed the uber module to `uberxplore.uber` from `uberxplore.services`

There are multiple options for sending over the addresses to Google's API, and I chose the easiest - concatenate each address piece from Yelp by doing `location.address.join(', ')`. So far I know that the wrong coordinates came back for Musee d’Orsay, but worked for Sainte-Chapelle.
