### PR TITLE
(cleanup) Lowercase Uber

### DIFF
--- a/client/app/auth/auth.html
+++ b/client/app/auth/auth.html
@@ -3,7 +3,7 @@
     <div class="title">Xplore</div>
     <div class="vertical">
       <div class="horizontal">
-        <a class="sign-in" target="_self" href="/uber/auth">Sign in with UBER</a>
+        <a class="sign-in" target="_self" href="/uber/auth">Sign in with Uber</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I think it should be lowercase Uber unless we are showing the actual UBER logo, since that is how they refer to themselves all over their website.
