### PR TITLE
Fixed when Itinerary button from Explore view was active

### DIFF
--- a/client/app/explore/explore.html
+++ b/client/app/explore/explore.html
@@ -35,11 +35,13 @@
 
     <!-- Go to ItineraryList view to check out itinerary so far -->
   <!-- real footer only shows when we have results -->
-  <div class="explore-footer" ng-show="!isLoading && !newSearch"><span ng-click="reset()">New Search</span></div>
-  <div class="explore-footer" ng-show="!isLoading && !newSearch"><a ui-sref="list">Itinerary</a></div>
-  <div class="explore-footer" ng-show="!isLoading && !newSearch && !!exploreResults.length"><span ng-click="addToItinerary(currentIndex)">Save</span></div><!-- non-functional footer shows on newSearch and on isLoading -->
-  <div class="explore-footer" ng-show="newSearch || isLoading">New Search</div>
-  <div class="explore-footer" ng-show="newSearch || isLoading">Itinerary</div>
-  <div class="explore-footer" ng-show="newSearch || isLoading">Save</div>
+  <div class="explore-footer enabled" ng-show="!isLoading && !newSearch"><span ng-click="reset()">New Search</span></div>
+  <div class="explore-footer enabled" ng-show="!isLoading && !newSearch && !!Locations.length"><a ui-sref="list">Itinerary</a></div>
+  <div class="explore-footer disabled" ng-show="!isLoading && !newSearch && !Locations.length">Itinerary</div>
+  <div class="explore-footer enabled" ng-show="!isLoading && !newSearch && !!exploreResults.length"><span ng-click="addToItinerary(currentIndex)">Save</span></div><!-- non-functional footer shows on newSearch and on isLoading -->
+  <div class="explore-footer disabled" ng-show="newSearch || isLoading">New Search</div>
+  <div class="explore-footer enabled" ng-show="(newSearch || isLoading) && !!Locations.length"><a ui-sref="list">Itinerary</a></div>
+  <div class="explore-footer disabled" ng-show="(newSearch || isLoading) && !Locations.length">Itinerary</div>
+  <div class="explore-footer disabled" ng-show="newSearch || isLoading">Save</div>
 
 </div>

--- a/client/app/explore/explore.js
+++ b/client/app/explore/explore.js
@@ -8,6 +8,9 @@ angular.module('uberxplore.explore', ['ngTouch', 'ngAnimate', 'uberxplore.geocoo
   // start with loading state being false, flip to true while Yelp API call runs
   // flip back to false after yelp results are loaded
   $scope.isLoading = false;
+
+  // scope variable for Locations
+  $scope.Locations = Locations;
   
   $scope.exploreResults = [];
 

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -152,7 +152,6 @@ a {
 }
 
 .explore-footer {
-  color: #06ACC9;
   padding-top: 5px;
   padding-bottom: 5px;
   float: left;
@@ -161,6 +160,14 @@ a {
   width: 125px;
   height: 40px;
   overflow: hidden;
+}
+
+.disabled {
+  color: #888;
+}
+
+.enabled {
+  color: #06ACC9;
 }
 
 /* Auth */


### PR DESCRIPTION
Now itinerary button is only active when there are items in the itinerary
If there are itinerary items in the list when we are on the Explore landing page, button now takes us directly to itinerary
