### PR TITLE
(cleanup) Improved map label readability

### DIFF
--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -345,8 +345,7 @@ a {
 }
 
 .marker-labels {
-  color: white;
-  text-shadow: 2px 0 0 #000, 0 -2px 0 #000, 0 2px 0 #000, -2px 0 0 #000;
+  color: black;
   font-size: 1.75em;
 }
 


### PR DESCRIPTION
I think this makes it a lot easier to read instead of the outlined white letters (which was a hack anyway).
